### PR TITLE
Clarify build directions

### DIFF
--- a/src/contributing.tex
+++ b/src/contributing.tex
@@ -247,6 +247,7 @@ CMakeLists.txt  geometry  monte_carlo  simulation  sn_solver  utility
 > cmake ..
 > make -j4 
 > make doc
+> cd ..
 \end{lstlisting}
 }
 \end{frame}


### PR DESCRIPTION
@VitaminDonut370 went through steps and noted ambiguous directions after `make`. Added `cd ..` to go out of `build` directory and enter top level directory for subsequent steps.